### PR TITLE
bitcoin patch for miniupnpc > 1.6

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1167,10 +1167,14 @@ void ThreadMapPort2(void* parg)
 #ifndef UPNPDISCOVER_SUCCESS
     /* miniupnpc 1.5 */
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#elif MINIUPNPC_API_VERSION < 14
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* miniupnpc > 1.6 */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
 #endif
 
     struct UPNPUrls urls;


### PR DESCRIPTION
Hi,

I tried to compile on my centOS server the wallet but I had the following error because I use miniupnpc2.0 :
```
net.cpp: In function ‘void ThreadMapPort2(void*)’:
net.cpp:1173:74: error: invalid conversion from ‘int*’ to ‘unsigned char’ [-fpermissive]
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
                                                                          ^
net.cpp:1173:74: error: too few arguments to function ‘UPNPDev* upnpDiscover(int, const char*, const char*, int, int, unsigned char, int*)’
In file included from net.cpp:19:0:
/usr/include/miniupnpc/miniupnpc.h:62:1: note: declared here
 upnpDiscover(int delay, const char * multicastif,
 ^
make: *** [obj/net.o] Error 1
```

I found that dogecoin had the same problem so I implemented their fix.
I gave the exact same pull request to [Neblio](https://github.com/NeblioTeam/neblio/pull/11) and they merged it.

More info here :
dogecoin/dogecoin#1292
dogecoin/dogecoin#1293
dogecoin/dogecoin@984e204

Not related to the pull request, the link to the linux wallet is the same as the windows wallet on the website http://condensate.co/